### PR TITLE
Because why would linkerd use the standard helm resource config forma…

### DIFF
--- a/infrastructure/networking/linkerd/release.yaml
+++ b/infrastructure/networking/linkerd/release.yaml
@@ -81,8 +81,8 @@ spec:
     installNamespace: false
     jaeger:
       resources:
-        limits:
-          memory: 100Mi
+        memory:
+          limit: 100Mi
 ---
 apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease


### PR DESCRIPTION
…tting